### PR TITLE
Migrate from Travis to GitHub actions, support Rails 6.1 and Ruby 3.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7]
-        rails_version: [5.2.4.4, 6.0.3.4, 6.1.1]
+        ruby: [2.7, 3.0]
+        rails_version: [6.0.3.4, 6.1.1]
     env:
       RAILS_VERSION: ${{ matrix.rails_version }}
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  tests_rails:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [2.7]
+        rails_version: [5.2.4.4, 6.0.3.2]
+    env:
+      RAILS_VERSION: ${{ matrix.rails_version }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         ruby: [2.7]
-        rails_version: [5.2.4.4, 6.0.3.2]
+        rails_version: [5.2.4.4, 6.0.3.4, 6.1.1]
     env:
       RAILS_VERSION: ${{ matrix.rails_version }}
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-sudo: false
-language: ruby
-
-matrix:
-  include:
-    - rvm: 2.7.1
-      env: RAILS_VERSION=6.0.3.2
-    - rvm: 2.6.6
-      env: RAILS_VERSION=5.2.4.3

--- a/geo_monitor.gemspec
+++ b/geo_monitor.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency 'rails', '>= 5.1.4', '< 6.1'
+  s.add_dependency 'rails', '>= 5.2', '< 6.2'
   s.add_dependency 'faraday'
 
   s.add_development_dependency 'engine_cart', '~> 2.0'


### PR DESCRIPTION
This also removes CI for Rails 5.2